### PR TITLE
Point to legacy file-system to correct download errors

### DIFF
--- a/contexts/DownloadContext.tsx
+++ b/contexts/DownloadContext.tsx
@@ -1,4 +1,4 @@
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { openDocumentTree, mkdir, createFile, moveFile, unlink, stat, listFiles, exists } from "@joplin/react-native-saf-x";
 import { unzip, subscribe } from 'react-native-zip-archive';
 import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';


### PR DESCRIPTION
Current usage is deprecated and on attempted download will throw an error. Pointing to the legacy version will allow the download to complete. Should probably update to the newer network task handlers instead long term.